### PR TITLE
Fixed a bug that was killing ModMountRoomObjectsWindow when deleting …

### DIFF
--- a/Source/ROM/ROM/UserInteraction/OptionsFilter.cs
+++ b/Source/ROM/ROM/UserInteraction/OptionsFilter.cs
@@ -94,7 +94,7 @@ namespace ROM.UserInteraction
 
         public int RemoveOption(TOption option)
         {
-            int result = AllOptionsList.RemoveAll(opt => Equals(opt, option));
+            int result = AllOptionsList.RemoveAll(opt => Equals(opt.Value, option));
 
             if (result != 0)
                 UpdateFilteredOptions();


### PR DESCRIPTION
…an object due to the filtered options not being removed correctly